### PR TITLE
修复send_private_msg消息发送失败的问题

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -128,6 +128,9 @@
                                 <button class="btn btn-primary" onclick="addMonitorUser()">添加</button>
                             </div>
                             <div class="form-help">
+                                <small style="color:red">请在QQ号输入微信昵称，用于消息发送</small>
+                            </div>
+                            <div class="form-help">
                                 <small>请输入微信昵称和对应的QQ号，用于消息转发时的用户ID映射</small>
                             </div>
                         </div>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -240,12 +240,6 @@ async function addMonitorUser() {
         return;
     }
     
-    // 验证QQ号格式（纯数字）
-    if (!/^\d+$/.test(user_id)) {
-        showToast('QQ号必须是纯数字', 'error');
-        return;
-    }
-    
     try {
         const response = await fetch('/api/monitor/users', {
             method: 'POST',


### PR DESCRIPTION
修复send_private_msg消息发送失败，api响应：[status=send failed, retcode=1500]。
发送失败原因：send_private_msg是获取user_id作为wxauto的SendMsg的微信昵称来发送消息的，user_id对应的是页面的QQ号，但是页面QQ号有数字输入校验，不能输入微信昵称，输入任意数字的话wxauto不能定位到对应的微信好友，导致消息发送失败。